### PR TITLE
npmjs ではなく GitHub への参照に変更します

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,39 +4,35 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@umm/accessor_utility_core": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@umm/accessor_utility_core/-/accessor_utility_core-1.0.7.tgz",
-      "integrity": "sha512-J38a3RcRMdLLfjRsr2ikuBwU3neA4Oahtq8RV5en2rouHSa3SXskLT5naapKhKm9PGK+JjA1nClOIf8kTbgWGQ==",
-      "requires": {
-        "glob": "7.1.2",
-        "mkdirp": "0.5.1",
-        "ncp": "2.0.0",
-        "rimraf": "2.6.1"
-      }
-    },
     "@umm/accessor_utility_monobehaviour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@umm/accessor_utility_monobehaviour/-/accessor_utility_monobehaviour-1.0.0.tgz",
-      "integrity": "sha512-BMrGYZmCqx40Q1jQI05L64kYsoZ95b2oGJVConEZChqTHWiCbpvBZviZ27bGyyzX6ndhHHLyw729FFpmLYc1Vg==",
+      "version": "github:umm-projects/accessor_utility_monobehaviour#b239634f0dab1d930294f3baa11cfc5144475bb6",
       "requires": {
-        "@umm/accessor_utility_core": "1.0.7",
-        "@umm/unirx": "5.5.4",
+        "@umm/accessor_utility_core": "github:umm-projects/accessor_utility_core#3c4ce37099d8cec530c537cc0e151aafde693166",
+        "@umm/unirx": "github:umm-projects/unirx#8ded122cd432aa0b3c8ea44b53953d308e416406",
         "glob": "7.1.2",
         "mkdirp": "0.5.1",
         "ncp": "2.0.0",
         "rimraf": "2.6.1"
-      }
-    },
-    "@umm/unirx": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/@umm/unirx/-/unirx-5.5.4.tgz",
-      "integrity": "sha512-TYrBjpQflWchDXrn6BGTi96tRIzdlOfeeTXodDwsSH1aJ4OY7AMRkJ4wJMxtsHi55w+EDxRfP0HN16rCGih0sw==",
-      "requires": {
-        "glob": "7.1.2",
-        "mkdirp": "0.5.1",
-        "ncp": "2.0.0",
-        "rimraf": "2.6.1"
+      },
+      "dependencies": {
+        "@umm/accessor_utility_core": {
+          "version": "github:umm-projects/accessor_utility_core#3c4ce37099d8cec530c537cc0e151aafde693166",
+          "requires": {
+            "glob": "7.1.2",
+            "mkdirp": "0.5.1",
+            "ncp": "2.0.0",
+            "rimraf": "2.6.1"
+          }
+        },
+        "@umm/unirx": {
+          "version": "github:umm-projects/unirx#8ded122cd432aa0b3c8ea44b53953d308e416406",
+          "requires": {
+            "glob": "7.1.2",
+            "mkdirp": "0.5.1",
+            "ncp": "2.0.0",
+            "rimraf": "2.6.1"
+          }
+        }
       }
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "scripts"
   ],
   "dependencies": {
-    "@umm/accessor_utility_monobehaviour": "~1",
+    "@umm/accessor_utility_monobehaviour": "github:umm-projects/accessor_utility_monobehaviour.git",
     "glob": "^7.1.2",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
* JS じゃないファイルを npmjs で管理するのは NG かと思い、GitHub を参照するように変更しました。